### PR TITLE
Remove leading _ from format argument (broken with R57)

### DIFF
--- a/kagefunc.py
+++ b/kagefunc.py
@@ -193,7 +193,7 @@ def squaremask(clip: vs.VideoNode, width: int, height: int, offset_x: int, offse
     mask_format = clip.format.replace(color_family=vs.GRAY, subsampling_w=0, subsampling_h=0)
     white = 1 if mask_format.sample_type == vs.FLOAT else (1 << bits) - 1
 
-    center = core.std.BlankClip(clip, width=width, height=height, _format=mask_format, color=white, length=1)
+    center = core.std.BlankClip(clip, width=width, height=height, format=mask_format, color=white, length=1)
 
     if offset_x:
         left = core.std.BlankClip(center, width=offset_x, height=height, color=0)

--- a/tests.py
+++ b/tests.py
@@ -9,12 +9,12 @@ import kagefunc as kgf
 
 class KagefuncTests(unittest.TestCase):
     BLACK_SAMPLE_CLIP = vs.core.std.BlankClip(
-        _format=vs.YUV420P8, width=160, height=120, color=[0, 128, 128], length=100
+        format=vs.YUV420P8, width=160, height=120, color=[0, 128, 128], length=100
     )
     WHITE_SAMPLE_CLIP = vs.core.std.BlankClip(
-        _format=vs.YUV420P8, width=160, height=120, color=[255, 128, 128], length=100
+        format=vs.YUV420P8, width=160, height=120, color=[255, 128, 128], length=100
     )
-    GREYSCALE_SAMPLE_CLIP = vs.core.std.BlankClip(_format=vs.GRAY8, width=160, height=120, color=[255])
+    GREYSCALE_SAMPLE_CLIP = vs.core.std.BlankClip(format=vs.GRAY8, width=160, height=120, color=[255])
 
     def test_retinex_edgemask(self):
         mask = kgf.retinex_edgemask(self.BLACK_SAMPLE_CLIP)


### PR DESCRIPTION
VapourSynth R57 no longer strips a leading _ and recommends to instead append _ to avoid python keywords. Since the keyword does not cause issues in this case, the _ can be removed entirely.

See https://github.com/vapoursynth/vapoursynth/commit/617ac8d98ffc5d4d02816284cb1d4dd534b51c65 and the changelog of R57 for details.